### PR TITLE
11 add type check or validation to the call type of annotation

### DIFF
--- a/backend/file/urls.py
+++ b/backend/file/urls.py
@@ -1,6 +1,6 @@
 from django.urls import path
 from filebrowser.sites import site
-from .views import file_download_view, file_list_view, FileList, FileDetail
+from .views import file_download_view, file_list_view, FileList, FileDetail,FileListDelete
 
 app_name = 'file'
 
@@ -9,5 +9,6 @@ urlpatterns = [
     path('scan/', file_list_view),
     path('download/', file_download_view),
     path('', FileList.as_view(), name='filelist'),
-    path('<int:pk>/', FileDetail.as_view(), name='filedetail')
+    path('<int:pk>/', FileDetail.as_view(), name='filedetail'),
+    path('delete/', FileListDelete.as_view(), name='list'),
 ]

--- a/backend/file/views.py
+++ b/backend/file/views.py
@@ -1,16 +1,17 @@
 from django.shortcuts import HttpResponse
+from django.http import FileResponse, Http404
 from filebrowser.base import FileListing, FileObject
 from filebrowser.sites import site
+from rest_framework import generics, status
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.response import Response
 from rest_framework.permissions import IsAuthenticated
+from rest_framework.views import APIView
 from .models import File
 from .serializers import FileSerializer
-from rest_framework import generics
 import soundfile as sf
 import math
 import os
-from django.http import FileResponse, Http404
 
 site.directory = "/audio/"
 
@@ -87,6 +88,15 @@ class FileList(CreateListModelMixin, generics.ListCreateAPIView):
     filterset_fields = {
         'id': ["in", "exact"]
     }
+
+#This view would handle Files delete
+class FileListDelete(APIView):
+    def delete(self, request, *args, **kwargs):
+        ids = request.query_params.get('ids').split(',')
+        if ids:
+            queryset = File.objects.filter(id__in=ids)
+            queryset.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
 
 
 class FileDetail(generics.RetrieveUpdateDestroyAPIView):

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,7 +37,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./backend:/backend
-      - ../audio:/backend/media/audio:ro
+      - ../data/audio:/backend/media/audio:ro
       - ../spectrogram:/backend/media/spectrogram
       - ../audio_clips:/backend/media/audio_clips
     ports:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -37,7 +37,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./backend:/backend
-      - ../data/audio:/backend/media/audio:ro
+      - ${FILE_PATH}:/backend/media/audio:ro
       - ../spectrogram:/backend/media/spectrogram
       - ../audio_clips:/backend/media/audio_clips
     ports:

--- a/docker-compose.sfu.yml
+++ b/docker-compose.sfu.yml
@@ -22,7 +22,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./backend:/backend
-      - ../data/for_annotation:/backend/media/audio:ro
+      - ${FILE_PATH}:/backend/media/audio:ro
       - ../spectrogram:/backend/media/spectrogram
       - ../audio_clips:/backend/media/audio_clips
       - backend_media:/backend/media

--- a/docker-compose.sfu.yml
+++ b/docker-compose.sfu.yml
@@ -22,7 +22,7 @@ services:
     restart: unless-stopped
     volumes:
       - ./backend:/backend
-      - ../data/audio:/backend/media/audio:ro
+      - ../data/for_annotation:/backend/media/audio:ro
       - ../spectrogram:/backend/media/spectrogram
       - ../audio_clips:/backend/media/audio_clips
       - backend_media:/backend/media

--- a/frontend/src/components/Annotation/Annotation.jsx
+++ b/frontend/src/components/Annotation/Annotation.jsx
@@ -38,7 +38,6 @@ import {
   SIS_options,
   kw_ecotype_options,
   pod_options,
-  signal_type_options,
   call_type_options,
   confidence_options,
 } from "./annotationFields";

--- a/frontend/src/components/Annotation/Annotation.jsx
+++ b/frontend/src/components/Annotation/Annotation.jsx
@@ -421,7 +421,9 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                     variant='outlined'
                     name='comments'
                     value={comments || ""}
-                    onChange={handleChange}
+                    onChange={(e) =>
+                      handleChange(e, e.target.value, "create-option", "comments")
+                    }
                     fullWidth
                   />
                 ) : (

--- a/frontend/src/components/Annotation/Annotation.jsx
+++ b/frontend/src/components/Annotation/Annotation.jsx
@@ -321,7 +321,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                     onChange={(e, value, reason) =>
                       handleChange(e, value, reason, "sound_id_species")
                     }
-                    value={sound_id_species}
+                    value={sound_id_species || ""}
                     filterOptions={handleFilterOptions}
                     getOptionLabel={handleGetOptionLabel}
                     renderOption={(option) => option.value}
@@ -341,7 +341,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                     onChange={(e, value, reason) =>
                       handleChange(e, value, reason, "kw_ecotype")
                     }
-                    value={kw_ecotype}
+                    value={kw_ecotype || ""}
                     filterOptions={handleFilterOptions}
                     getOptionLabel={handleGetOptionLabel}
                     renderOption={(option) => option.value}
@@ -361,7 +361,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                     onChange={(e, value, reason) =>
                       handleChange(e, value, reason, "call_type")
                     }
-                    value={call_type}
+                    value={call_type || ""}
                     filterOptions={handleFilterOptions}
                     getOptionLabel={handleGetOptionLabel}
                     renderOption={(option) => option.value}
@@ -381,7 +381,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                     onChange={(e, value, reason) =>
                       handleChange(e, value, reason, "pod")
                     }
-                    value={pod}
+                    value={pod || ""}
                     filterOptions={handleFilterOptions}
                     getOptionLabel={handleGetOptionLabel}
                     renderOption={(option) => option.value}
@@ -403,7 +403,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                     onChange={(e, value, reason) =>
                       handleChange(e, value, reason, "confidence_level")
                     }
-                    value={confidence_level}
+                    value={confidence_level || ""}
                     filterOptions={handleFilterOptions}
                     getOptionLabel={handleGetOptionLabel}
                     renderOption={(option) => option.value}
@@ -420,7 +420,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                   <TextField
                     variant='outlined'
                     name='comments'
-                    value={comments}
+                    value={comments || ""}
                     onChange={handleChange}
                     fullWidth
                   />
@@ -482,7 +482,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                       startIcon={<ClearIcon />}
                       onClick={handleClearHistory}
                     >
-                      Clear Form
+                      Clear History
                     </Button>
                   )}
                 </Grid>

--- a/frontend/src/components/Annotation/Annotation.jsx
+++ b/frontend/src/components/Annotation/Annotation.jsx
@@ -31,6 +31,19 @@ import { useDispatch, useSelector } from "react-redux";
 import PropTypes from "prop-types";
 import convert from "convert-units";
 import Moment from "react-moment";
+import Autocomplete, {
+  createFilterOptions,
+} from "@material-ui/lab/Autocomplete";
+import {
+  SIS_options,
+  kw_ecotype_options,
+  pod_options,
+  signal_type_options,
+  call_type_options,
+  confidence_options,
+} from "./annotationFields";
+
+const filter = createFilterOptions();
 
 const useStyles = makeStyles((theme) => ({
   avatar: {
@@ -90,12 +103,58 @@ const Annotation = ({ annotation, newBatch, editable }) => {
     created_at,
   } = formData;
 
-  const handleChange = (e) => {
-    setFormData({
-      ...formData,
-      [e.target.name]: e.target.value,
-    });
+  const handleChange = (e, formValue, reason, field) => {
+    if (reason === "select-option") {
+      const { value } = formValue;
+      setFormData({
+        ...formData,
+        [field]: value,
+      });
+    }
+
+    if (reason === "create-option") {
+      setFormData({
+        ...formData,
+        [field]: formValue,
+      });
+    }
+    if (reason === "clear") {
+      setFormData({
+        ...formData,
+        [field]: "",
+      });
+    }
   };
+
+  const handleFilterOptions = (options, params) => {
+    const filtered = filter(options, params);
+
+    if (params.inputValue !== "") {
+      filtered.push({
+        inputValue: params.inputValue,
+        value: `Press Enter to add "${params.inputValue}"`,
+      });
+    }
+
+    return filtered;
+  };
+
+  const handleGetOptionLabel = (option) => {
+    // Value selected with enter, right from the input
+    if (typeof option === "string") {
+      return option;
+    }
+    // Add "xxx" option created dynamically
+    if (option.inputValue) {
+      return option.inputValue;
+    }
+    // Regular option
+    return option.value;
+  };
+
+  const handleRenderInput = (params) => (
+    <TextField variant='outlined' {...params} />
+  );
 
   const handleSubmit = () => {
     const annotationData = {
@@ -256,11 +315,18 @@ const Annotation = ({ annotation, newBatch, editable }) => {
               <Grid item xs={3}>
                 <Typography variant='subtitle1'>SIS:</Typography>
                 {editable || newBatch ? (
-                  <TextField
-                    variant='outlined'
-                    name='sound_id_species'
+                  <Autocomplete
+                    freeSolo
+                    handleHomeEndKeys
+                    options={SIS_options}
+                    onChange={(e, value, reason) =>
+                      handleChange(e, value, reason, "sound_id_species")
+                    }
                     value={sound_id_species}
-                    onChange={handleChange}
+                    filterOptions={handleFilterOptions}
+                    getOptionLabel={handleGetOptionLabel}
+                    renderOption={(option) => option.value}
+                    renderInput={handleRenderInput}
                   />
                 ) : (
                   <Typography>{sound_id_species}</Typography>
@@ -269,11 +335,18 @@ const Annotation = ({ annotation, newBatch, editable }) => {
               <Grid item xs={3} container direction='column'>
                 <Typography variant='subtitle1'>KW ecotype:</Typography>
                 {editable || newBatch ? (
-                  <TextField
-                    variant='outlined'
-                    name='kw_ecotype'
+                  <Autocomplete
+                    freeSolo
+                    handleHomeEndKeys
+                    options={kw_ecotype_options}
+                    onChange={(e, value, reason) =>
+                      handleChange(e, value, reason, "kw_ecotype")
+                    }
                     value={kw_ecotype}
-                    onChange={handleChange}
+                    filterOptions={handleFilterOptions}
+                    getOptionLabel={handleGetOptionLabel}
+                    renderOption={(option) => option.value}
+                    renderInput={handleRenderInput}
                   />
                 ) : (
                   <Typography>{kw_ecotype}</Typography>
@@ -282,11 +355,18 @@ const Annotation = ({ annotation, newBatch, editable }) => {
               <Grid item xs={3} container direction='column'>
                 <Typography variant='subtitle1'>Call Type:</Typography>
                 {editable || newBatch ? (
-                  <TextField
-                    variant='outlined'
-                    name='call_type'
+                  <Autocomplete
+                    freeSolo
+                    handleHomeEndKeys
+                    options={call_type_options}
+                    onChange={(e, value, reason) =>
+                      handleChange(e, value, reason, "call_type")
+                    }
                     value={call_type}
-                    onChange={handleChange}
+                    filterOptions={handleFilterOptions}
+                    getOptionLabel={handleGetOptionLabel}
+                    renderOption={(option) => option.value}
+                    renderInput={handleRenderInput}
                   />
                 ) : (
                   <Typography>{call_type}</Typography>
@@ -295,11 +375,18 @@ const Annotation = ({ annotation, newBatch, editable }) => {
               <Grid item container xs={3} direction='column'>
                 <Typography variant='subtitle1'>Pod:</Typography>
                 {editable || newBatch ? (
-                  <TextField
-                    variant='outlined'
-                    name='pod'
+                  <Autocomplete
+                    freeSolo
+                    handleHomeEndKeys
+                    options={pod_options}
+                    onChange={(e, value, reason) =>
+                      handleChange(e, value, reason, "pod")
+                    }
                     value={pod}
-                    onChange={handleChange}
+                    filterOptions={handleFilterOptions}
+                    getOptionLabel={handleGetOptionLabel}
+                    renderOption={(option) => option.value}
+                    renderInput={handleRenderInput}
                   />
                 ) : (
                   <Typography>{pod}</Typography>
@@ -310,12 +397,18 @@ const Annotation = ({ annotation, newBatch, editable }) => {
               <Grid item xs={4}>
                 <Typography variant='subtitle1'>Confidence level:</Typography>
                 {editable || newBatch ? (
-                  <TextField
-                    variant='outlined'
+                  <Autocomplete
+                    freeSolo
+                    handleHomeEndKeys
+                    options={confidence_options}
+                    onChange={(e, value, reason) =>
+                      handleChange(e, value, reason, "confidence_level")
+                    }
                     value={confidence_level}
-                    name='confidence_level'
-                    onChange={handleChange}
-                    fullWidth
+                    filterOptions={handleFilterOptions}
+                    getOptionLabel={handleGetOptionLabel}
+                    renderOption={(option) => option.value}
+                    renderInput={handleRenderInput}
                   />
                 ) : (
                   <Typography>{confidence_level}</Typography>

--- a/frontend/src/components/Annotation/Annotation.jsx
+++ b/frontend/src/components/Annotation/Annotation.jsx
@@ -8,7 +8,12 @@ import {
   TextField,
   CardHeader,
   Avatar,
+  Select,
+  Input,
+  MenuItem,
   IconButton,
+  Checkbox,
+  ListItemText,
 } from "@material-ui/core";
 import EditOutlinedIcon from "@material-ui/icons/EditOutlined";
 import DeleteForeverOutlinedIcon from "@material-ui/icons/DeleteForeverOutlined";
@@ -72,12 +77,23 @@ const formInit = {
   comments: "",
   created_at: "",
 };
+const ITEM_HEIGHT = 48;
+const ITEM_PADDING_TOP = 8;
+const MenuProps = {
+  PaperProps: {
+    style: {
+      maxHeight: ITEM_HEIGHT * 4.5 + ITEM_PADDING_TOP,
+      width: 250,
+    },
+  },
+};
 
 const Annotation = ({ annotation, newBatch, editable }) => {
   const classes = useStyles();
   const dispatch = useDispatch();
   const [formData, setFormData] = useState(formInit);
   const [formDataCopy, setFormDataCopy] = useState(null);
+  const [species, setSpecies] = useState([]);
 
   const { selectedRegion, currentRegions, annotationHistory } = useSelector(
     (state) => state.annotation
@@ -158,6 +174,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
   const handleSubmit = () => {
     const annotationData = {
       ...formData,
+      sound_id_species: species.join("/"),
       start: (formData.start * 1).toFixed(3),
       end: (formData.end * 1).toFixed(3),
       freq_min: (formData.freq_min * 1).toFixed(3),
@@ -180,6 +197,7 @@ const Annotation = ({ annotation, newBatch, editable }) => {
   const handleSaveChange = () => {
     const updatedFromdata = {
       ...formData,
+      sound_id_species: species.join("/"),
       start: (formData.start * 1).toFixed(3),
       end: (formData.end * 1).toFixed(3),
       freq_min: (formData.freq_min * 1).toFixed(3),
@@ -207,11 +225,19 @@ const Annotation = ({ annotation, newBatch, editable }) => {
       confidence_level: "",
       comments: "",
     });
+    setSpecies([]);
   };
 
   useEffect(() => {
     setFormData(annotation);
+    if (annotation.sound_id_species)
+      setSpecies(annotation.sound_id_species.split("/"));
+    else setSpecies([]);
   }, [annotation]);
+
+  const handleSpeciesSelect = (e) => {
+    setSpecies(e.target.value);
+  };
 
   useEffect(() => {
     const { id, segment, batch } = annotation;
@@ -314,19 +340,22 @@ const Annotation = ({ annotation, newBatch, editable }) => {
               <Grid item xs={3}>
                 <Typography variant='subtitle1'>SIS:</Typography>
                 {editable || newBatch ? (
-                  <Autocomplete
-                    freeSolo
-                    handleHomeEndKeys
-                    options={SIS_options}
-                    onChange={(e, value, reason) =>
-                      handleChange(e, value, reason, "sound_id_species")
-                    }
-                    value={sound_id_species || ""}
-                    filterOptions={handleFilterOptions}
-                    getOptionLabel={handleGetOptionLabel}
-                    renderOption={(option) => option.value}
-                    renderInput={handleRenderInput}
-                  />
+                  <Select
+                    multiple
+                    value={species}
+                    onChange={handleSpeciesSelect}
+                    input={<Input />}
+                    renderValue={(selected) => selected.join("/")}
+                    MenuProps={MenuProps}
+                    fullWidth
+                  >
+                    {SIS_options.map((item) => (
+                      <MenuItem key={item.id} value={item.value}>
+                        <Checkbox checked={species.indexOf(item.value) > -1} />
+                        <ListItemText primary={item.value} />
+                      </MenuItem>
+                    ))}
+                  </Select>
                 ) : (
                   <Typography>{sound_id_species}</Typography>
                 )}
@@ -422,7 +451,12 @@ const Annotation = ({ annotation, newBatch, editable }) => {
                     name='comments'
                     value={comments || ""}
                     onChange={(e) =>
-                      handleChange(e, e.target.value, "create-option", "comments")
+                      handleChange(
+                        e,
+                        e.target.value,
+                        "create-option",
+                        "comments"
+                      )
                     }
                     fullWidth
                   />

--- a/frontend/src/components/Annotation/AnnotationPanel.jsx
+++ b/frontend/src/components/Annotation/AnnotationPanel.jsx
@@ -232,7 +232,6 @@ const AnnotationPanel = () => {
   }, [tab, progressMapLoading]);
 
   useEffect(() => {
-    console.log(latestTab)
     if(latestTab) setTab(latestTab)
   },[latestTab])
 

--- a/frontend/src/components/Annotation/annotationFields.js
+++ b/frontend/src/components/Annotation/annotationFields.js
@@ -1,0 +1,59 @@
+const SIS_options = [
+    { id: 1, value: "KW", description: "Killer whale" },
+    { id: 2, value: "KW?", description: "potential killer whale (if it was unknown but had the potential to be KW, it fell into this category)" },
+    { id: 3, value: "HW", description: "Humpback whale" },
+    { id: 4, value: "HW?", description: "potential humpback whale (certainly not a KW, possibly  a HW)" },
+    { id: 5, value: "HW/KW?", description: "either HW or KW, cannot determine" },
+    { id: 6, value: "PWSD", description: "Pacific White Sided Dolphin" },
+    { id: 7, value: "PWSD?", description: "potential Pacific White Sided Dolphin" },
+    { id: 8, value: "KW/PWSD?", description: "either KW or PWSD, too faint or indistinct to determine" },
+    { id: 9, value: "GW", description: "Grey Whale" },
+    { id: 10, value: "GW?", description: "potential Grey Whale" },
+    { id: 11, value: "HW/GW?", description: "either HW or GW, cannot determine without further review" },
+    { id: 12, value: "Odontocete", description: "vocalizations from a small unidentified odontocete, not PWSD" },
+    { id: 13, value: "Odontocete?", description: "potential vocalizations from a small unidentified odontocete, not PWSD" },
+    { id: 14, value: "Rissos", description: "Risso’s Dolphin" },
+    { id: 15, value: "SPW", description: "Sperm Whale" },
+    { id: 16, value: "Vessel Noise", description: "Vessel Noise" },
+    { id: 17, value: "Clang", description: "some metallic-like anthropogenic clang with unknown source" },
+    { id: 18, value: "Mooring", description: "noise likely derived from the instrument’s mooring equipment" },
+    { id: 19, value: "Sonar", description: "Noise likely due to sonar activity" },
+    { id: 20, value: "UNK", description: "Unknown - unable to identify or attribute sound to a definitive class" },
+];
+
+const kw_ecotype_options = [
+    { id: 1, value: "SRKW", description: "Southern Resident Killer Whale" },
+    { id: 2, value: "NRKW", description: "Northern Resident Killer Whale" },
+    { id: 3, value: "TKW", description: "Transient (Bigg’s) Killer Whale" },
+    { id: 4, value: "UKW", description: "Outercoast Transient (Bigg’s) Killer Whale" },
+    { id: 5, value: "OKW", description: "Offshore Killer Whale" },
+    { id: 6, value: "Unknown", description: "unable to identify or attribute sound to a definitive class" },
+];
+
+const pod_options = [
+    { id: 1, value: "J", description: "J pod" },
+    { id: 2, value: "K", description: "K pod" },
+    { id: 3, value: "L", description: "L pod" },
+    { id: 4, value: "Unknown", description: "unable to identify or attribute sound to a definitive pod" },
+    { id: 5, value: "K/L", description: "K or L pod (because of the call types they have in common)" },
+];
+
+const signal_type_options = [
+    { id: 1, value: "PC", description: "Pulsed call" },
+    { id: 2, value: "W", description: "Whistle" },
+    { id: 3, value: "CK", description: "(Echolocation) click" },
+    { id: 4, value: "Unknown", description: "unable to identify or attribute sound to a definitive signal type" },
+];
+
+const call_type_options = [
+    { id: 1, value: "S01/S02", description: "S01 or S02 call (attribution uncertain)" },
+    { id: 2, value: "Unknown", description: "unable to identify or attribute sound to a definitive call type" },
+];
+
+const confidence_options = [
+    { id: 1, value: "High" },
+    { id: 2, value: "Medium" },
+    { id: 3, value: "Low" },
+];
+
+export { SIS_options, kw_ecotype_options, pod_options, signal_type_options, call_type_options, confidence_options };

--- a/frontend/src/components/Annotation/annotationFields.js
+++ b/frontend/src/components/Annotation/annotationFields.js
@@ -3,13 +3,13 @@ const SIS_options = [
     { id: 2, value: "KW?", description: "potential killer whale (if it was unknown but had the potential to be KW, it fell into this category)" },
     { id: 3, value: "HW", description: "Humpback whale" },
     { id: 4, value: "HW?", description: "potential humpback whale (certainly not a KW, possibly  a HW)" },
-    { id: 5, value: "HW/KW?", description: "either HW or KW, cannot determine" },
+   // { id: 5, value: "HW/KW?", description: "either HW or KW, cannot determine" },
     { id: 6, value: "PWSD", description: "Pacific White Sided Dolphin" },
     { id: 7, value: "PWSD?", description: "potential Pacific White Sided Dolphin" },
-    { id: 8, value: "KW/PWSD?", description: "either KW or PWSD, too faint or indistinct to determine" },
+    //{ id: 8, value: "KW/PWSD?", description: "either KW or PWSD, too faint or indistinct to determine" },
     { id: 9, value: "GW", description: "Grey Whale" },
     { id: 10, value: "GW?", description: "potential Grey Whale" },
-    { id: 11, value: "HW/GW?", description: "either HW or GW, cannot determine without further review" },
+   // { id: 11, value: "HW/GW?", description: "either HW or GW, cannot determine without further review" },
     { id: 12, value: "Odontocete", description: "vocalizations from a small unidentified odontocete, not PWSD" },
     { id: 13, value: "Odontocete?", description: "potential vocalizations from a small unidentified odontocete, not PWSD" },
     { id: 14, value: "Rissos", description: "Risso’s Dolphin" },
@@ -34,8 +34,12 @@ const pod_options = [
     { id: 1, value: "J", description: "J pod" },
     { id: 2, value: "K", description: "K pod" },
     { id: 3, value: "L", description: "L pod" },
-    { id: 4, value: "Unknown", description: "unable to identify or attribute sound to a definitive pod" },
-    { id: 5, value: "K/L", description: "K or L pod (because of the call types they have in common)" },
+    { id: 4, value: "JK", description: "JK pod" },
+    { id: 5, value: "JL", description: "JL pod" },
+    { id: 6, value: "KL", description: "KL pod" },
+    { id: 7, value: "JKL", description: "JKL pod" },
+    //{ id: 5, value: "K/L", description: "K or L pod (because of the call types they have in common)" },
+    { id: 8, value: "Unknown", description: "unable to identify or attribute sound to a definitive pod" },
 ];
 
 const signal_type_options = [
@@ -46,8 +50,9 @@ const signal_type_options = [
 ];
 
 const call_type_options = [
-    { id: 1, value: "S01/S02", description: "S01 or S02 call (attribution uncertain)" },
-    { id: 2, value: "Unknown", description: "unable to identify or attribute sound to a definitive call type" },
+    { id: 1, value: "S01", description: "S01 call (attribution uncertain)" },
+    { id: 2, value: "S02", description: "S02 call (attribution uncertain)" },
+    { id: 3, value: "Unknown", description: "unable to identify or attribute sound to a definitive call type" },
 ];
 
 const confidence_options = [

--- a/frontend/src/reducers/fileSlice.js
+++ b/frontend/src/reducers/fileSlice.js
@@ -1,6 +1,7 @@
 import { createAsyncThunk, createSlice } from '@reduxjs/toolkit';
 import axiosWithAuth from '../utils/axiosWithAuth';
 import { normalize, schema } from 'normalizr';
+import { queryFormater } from '../utils/segmentUtils';
 
 const initialState = {
     files: {},
@@ -50,10 +51,7 @@ export const scanFiles = createAsyncThunk(
 export const deleteFiles = createAsyncThunk(
     'file/deleteFiles',
     async ({ ids }) => {
-        const request = ids.map(id => {
-            return axiosWithAuth.delete(`/file/${id}/`);
-        });
-        await Promise.all(request);
+        queryFormater(ids).forEach(sub => axiosWithAuth.delete(`/file/delete/?ids=${sub.join(",")}`));
     }
 );
 


### PR DESCRIPTION
**Added some hard-coded options for annotation fields.**

**Users can select an option from a dropdown menu:**

<img width="587" alt="image" src="https://user-images.githubusercontent.com/34404957/196301221-022c1198-3ca4-4476-8556-49ee0f33b03a.png">


**Users can also use custom values:**

<img width="592" alt="image" src="https://user-images.githubusercontent.com/34404957/196301324-ba420b6c-4bf6-44ad-b22d-6f68ef60b566.png">

A few more things could be added in the future with MAIPL, such as showing descriptions when selecting an option, letting the admin user define the options, etc. 